### PR TITLE
Highlight weighted edges and enable clip node dragging

### DIFF
--- a/Editor/Scripts/GraphView/PlayableGraphView.cs
+++ b/Editor/Scripts/GraphView/PlayableGraphView.cs
@@ -112,6 +112,7 @@ namespace GBG.PlayableGraphMonitor.Editor.GraphView
 
             UpdateActiveEdges(context);
             RemoveUnusedElementsFromView();
+            SetNodesMovability(!context.AutoLayout);
 
             if (playableGraphChanged)
             {
@@ -264,6 +265,8 @@ namespace GBG.PlayableGraphMonitor.Editor.GraphView
             var portColor = GraphTool.GetPortColor(weight);
             inputPort.portColor = portColor;
             outputPort.portColor = portColor;
+            edge.inputColor = portColor;
+            edge.outputColor = portColor;
 
             if (edge.input != inputPort)
             {

--- a/Editor/Scripts/Node/AnimationClipPlayableNode.cs
+++ b/Editor/Scripts/Node/AnimationClipPlayableNode.cs
@@ -20,8 +20,12 @@ namespace GBG.PlayableGraphMonitor.Editor.Node
         {
             var banner = mainContainer.Q("divider");
             banner.style.height = StyleKeyword.Auto;
+            banner.pickingMode = PickingMode.Ignore;
 
-            _progressBar = new ProgressBar();
+            _progressBar = new ProgressBar
+            {
+                pickingMode = PickingMode.Ignore,
+            };
 #if !UNITY_2021_1_OR_NEWER
             var progressBarBg = _progressBar.Q<VisualElement>(className: "unity-progress-bar__background");
             progressBarBg.style.height = 17;
@@ -31,6 +35,7 @@ namespace GBG.PlayableGraphMonitor.Editor.Node
             _clipField = new ObjectField
             {
                 objectType = typeof(Motion),
+                pickingMode = PickingMode.Ignore,
             };
             var clipFieldSelector = _clipField.Q(className: "unity-object-field__selector");
             clipFieldSelector.style.display = DisplayStyle.None;

--- a/Editor/Scripts/Utility/GraphTool.cs
+++ b/Editor/Scripts/Utility/GraphTool.cs
@@ -99,19 +99,19 @@ namespace GBG.PlayableGraphMonitor.Editor.Utility
 
         public static Color GetPortColor(float weight)
         {
-            if (weight < 0)
+            if (weight <= 0)
             {
-                // In theory, there should be no inputs with negative weights in PlayableGraph
-                return PortNegativeWeightColor;
+                if (weight < 0)
+                {
+                    // In theory, there should be no inputs with negative weights in PlayableGraph
+                    return PortNegativeWeightColor;
+                }
+
+                var alpha = (weight + ColorAlphaFactor) / (1 + ColorAlphaFactor);
+                return new Color(1, 1, 1, alpha);
             }
 
-            if (weight > 1)
-            {
-                return PortOverflowWeightColor;
-            }
-
-            var alpha = (weight + ColorAlphaFactor) / (1 + ColorAlphaFactor);
-            return new Color(1, 1, 1, alpha);
+            return Color.red;
         }
 
         #endregion

--- a/Editor/Scripts/Window/PlayableGraphMonitorWindow.cs
+++ b/Editor/Scripts/Window/PlayableGraphMonitorWindow.cs
@@ -69,9 +69,6 @@ namespace GBG.PlayableGraphMonitor.Editor
 
         private long _nextUpdateViewTimeMS;
 
-        // ReSharper disable once IdentifierTypo
-        private bool _updateNodesMovability;
-
 
         private void OnEnable()
         {
@@ -129,11 +126,6 @@ namespace GBG.PlayableGraphMonitor.Editor
             // TODO FIXME CLIP_PROGRESS: If I reverse the order of these two method calls, the progress bar on the Clip node will become inaccurate. Why???
             DrawInspector();
             UpdateGraphView();
-
-            if (_updateNodesMovability)
-            {
-                _graphView.SetNodesMovability(!_autoLayoutToggle.value);
-            }
         }
 
         private void ShowButton(Rect pos)

--- a/Editor/Scripts/Window/PlayableGraphMonitorWindow_Toolbar.cs
+++ b/Editor/Scripts/Window/PlayableGraphMonitorWindow_Toolbar.cs
@@ -151,7 +151,6 @@ namespace GBG.PlayableGraphMonitor.Editor
             _autoLayoutToggle.RegisterValueChangedCallback(ToggleAutoLayout);
             _autoLayoutLabel = _autoLayoutToggle.Q<TextElement>(className: "unity-text-element");
             _autoLayoutLabel.style.color = _viewUpdateContext.AutoLayout ? NormalTextColor : NotableTextColor;
-            _updateNodesMovability = true;
             _toolbar.Add(_autoLayoutToggle);
 
             // Refresh rate popup
@@ -275,8 +274,6 @@ namespace GBG.PlayableGraphMonitor.Editor
             _autoLayoutLabel.style.color = _viewUpdateContext.AutoLayout
                 ? NormalTextColor
                 : NotableTextColor;
-
-            _updateNodesMovability = true;
         }
 
         private void OnRefreshRateChanged(ChangeEvent<Enum> evt)


### PR DESCRIPTION
## Summary
- Color edges with active weights in red for clearer graphs
- Allow AnimationClipPlayable nodes to participate in rectangle selection and dragging
- Update node movability automatically based on Auto Layout setting

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68909d8a5f3883269a66185557a771ba